### PR TITLE
feat: support custom bar classename, allow message use ReactNode

### DIFF
--- a/src/announcement/index.tsx
+++ b/src/announcement/index.tsx
@@ -7,11 +7,13 @@ export function Announcement({
   message,
   localStorageKey,
   display = true,
+  barClassName,
 }: {
   href: string;
-  message: string;
+  message: string | React.ReactNode;
   localStorageKey: string;
   display?: boolean;
+  barClassName?: string;
 }) {
   if (!display) {
     return null;
@@ -25,7 +27,7 @@ export function Announcement({
   }
 
   return (
-    <div className={styles.bar}>
+    <div className={`${styles.bar} ${barClassName}`}>
       <a href={href} className={styles.link}>
         {message}
       </a>


### PR DESCRIPTION
This PR supports custom classname of the Banner Bar style, and also supports passing in `ReactNode` as `message` type